### PR TITLE
Feature: Consume Enumerable Sections [LOYAL-1119]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rspec', '~>2.14'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'rspec', '~>2.14'
+  gem 'rspec'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rspec', '~>2.14'
+group :test do
+  gem 'rspec', '~>2.14'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.4.4)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec (~> 2.14)
+
+BUNDLED WITH
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rspec (~> 2.14)
+  rspec
 
 BUNDLED WITH
    2.1.4

--- a/lib/slither/generator.rb
+++ b/lib/slither/generator.rb
@@ -1,26 +1,27 @@
 class Slither
   class Generator
+    def initialize(definition)
+      @definition = definition
+    end
 
-		def initialize(definition)
-			@definition = definition
-		end
+    def generate(data)
+      @builder = []
+      @definition.sections.each do |section|
+        content = data[section.name]
+        if content
+          content = [content] if content.is_a?(Hash)
+          raise(Slither::RequiredSectionEmptyError, "Required section '#{section.name}' was empty.") unless content.any?
 
-		def generate(data)
-	    @builder = []
-	    @definition.sections.each do |section|
-	      content = data[section.name]
-	      if content
-  	      content = [content] if content.is_a?(Hash)
-  	      raise(Slither::RequiredSectionEmptyError, "Required section '#{section.name}' was empty.") unless content.any?
-  	      content.each do |row|
-  	        @builder << section.format(row)
-  	      end
-  	    else
-  	      raise(Slither::RequiredSectionEmptyError, "Required section '#{section.name}' was empty.") unless section.optional
-	      end
-	    end
-	    @builder.join("\n")
-		end
-
-	end
+          content.each do |row|
+            @builder << section.format(row)
+          end
+        else
+          unless section.optional
+            raise(Slither::RequiredSectionEmptyError, "Required section '#{section.name}' was empty.")
+          end
+        end
+      end
+      @builder.join("\n")
+    end
+  end
 end

--- a/lib/slither/generator.rb
+++ b/lib/slither/generator.rb
@@ -10,8 +10,8 @@ class Slither
 	    @definition.sections.each do |section|
 	      content = data[section.name]
 	      if content
-  	      content = [content] unless content.is_a?(Array)
-  	      raise(Slither::RequiredSectionEmptyError, "Required section '#{section.name}' was empty.") if content.empty?
+  	      content = [content] if content.is_a?(Hash)
+  	      raise(Slither::RequiredSectionEmptyError, "Required section '#{section.name}' was empty.") unless content.any?
   	      content.each do |row|
   	        @builder << section.format(row)
   	      end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -39,4 +39,24 @@ describe Slither::Generator do
     expected = "HEAD         1\n      Paul    Hewson\n      Dave     Evans\nFOOT         1"
     @generator.generate(@data).should == expected
   end
+
+  context "when body is not an array but enumerable" do
+    class CustomEnumerable
+      include Enumerable
+
+      RECORD = {:first => "Paul", :last => "Hewson" }
+
+      def each
+        3.times do
+          yield RECORD
+        end
+      end
+    end
+
+    it "should generate expected output" do
+      @data[:body] = CustomEnumerable.new
+      expected = "HEAD         1\n      Paul    Hewson\n      Paul    Hewson\n      Paul    Hewson\nFOOT         1"
+      @generator.generate(@data).should == expected
+    end
+  end
 end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -35,12 +35,17 @@ describe Slither::Generator do
     lambda {  @generator.generate(@data) }.should raise_error(Slither::RequiredSectionEmptyError, "Required section 'header' was empty.")
   end
 
+  it "should raise an error if there is no data for a required section" do
+    @data[:body] = []
+    lambda {  @generator.generate(@data) }.should raise_error(Slither::RequiredSectionEmptyError, "Required section 'body' was empty.")
+  end
+
   it "should generate a string" do
     expected = "HEAD         1\n      Paul    Hewson\n      Dave     Evans\nFOOT         1"
     @generator.generate(@data).should == expected
   end
 
-  context "when body is not an array but enumerable" do
+  context "when content is not an array but enumerable" do
     class CustomEnumerable
       include Enumerable
 
@@ -56,6 +61,14 @@ describe Slither::Generator do
     it "should generate expected output" do
       @data[:body] = CustomEnumerable.new
       expected = "HEAD         1\n      Paul    Hewson\n      Paul    Hewson\n      Paul    Hewson\nFOOT         1"
+      @generator.generate(@data).should == expected
+    end
+  end
+
+  context "when content is hash" do
+    it "should generate expected output" do
+      @data[:body] = {:first => "Paul", :last => "Hewson" }
+      expected = "HEAD         1\n      Paul    Hewson\nFOOT         1"
       @generator.generate(@data).should == expected
     end
   end


### PR DESCRIPTION
# Description

https://kaligo.atlassian.net/browse/LOYAL-1119
Yet it was necessary to pass array/hash data to generate output.
By slightly modifying `lib/slither/generator.rb` it is possible to pass an `Enumerable` such as a Sequel Dataset.