### PR TITLE
Add trailing newline to file to follow unix conventions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -77,6 +77,18 @@ or parse files already in that format into a nested hash:
    parsed_data = Slither.parseIo(io_object, :simple)
 
 
+TRAILING NEWLINE
+
+By default Slither does not add it.
+You can modify the behaviour by passing a generator level setting
+Slither.generate(:simple, test_data, true)
+
+If you wanna differ from the original settings you can do it by adding it to your definition
+Use :trailing_newline => true to add a trailing newline to a file
+Use :trailing_newline => false (default) to ignore trailing newline at the end of a file
+It overrides the generator level settings!
+
+
 == INSTALL:
 
 sudo gem install slither

--- a/lib/slither/generator.rb
+++ b/lib/slither/generator.rb
@@ -1,7 +1,9 @@
 class Slither
   class Generator
-    def initialize(definition)
+    def initialize(definition, trailing_newline = false)
       @definition = definition
+      @generator_should_add_trailing_newline = trailing_newline
+      @force_generator_to_add_newline = definition.options[:trailing_newline]
     end
 
     def generate(data)
@@ -21,7 +23,20 @@ class Slither
           end
         end
       end
-      @builder.join("\n")
+      generate_file_output
+    end
+
+    private
+
+    def generate_file_output
+      output = @builder.join("\n")
+      output.concat("\n") if add_trailing_newline?
+      output
+    end
+
+    def add_trailing_newline?
+      return true if @force_generator_to_add_newline
+      @generator_should_add_trailing_newline
     end
   end
 end

--- a/lib/slither/slither.rb
+++ b/lib/slither/slither.rb
@@ -18,10 +18,10 @@ class Slither
     definition
   end
 
-  def self.generate(definition_name, data)
+  def self.generate(definition_name, data, trailing_newline = false)
     definition = definition(definition_name)
     raise ArgumentError, "Definition name '#{name}' was not found." unless definition
-    generator = Generator.new(definition)
+    generator = Generator.new(definition, trailing_newline)
     generator.generate(data)
   end
 

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1,75 +1,135 @@
 require File.join(File.dirname(__FILE__), 'spec_helper')
 
 describe Slither::Generator do
-  before(:each) do
-    @definition = Slither.define :test do |d|
-      d.header do |h|
-        h.trap { |line| line[0,4] == 'HEAD' }
-        h.column :type, 4
-        h.column :file_id, 10
-      end
-      d.body do |b|
-        b.trap { |line| line[0,4] =~ /[^(HEAD|FOOT)]/ }
-        b.column :first, 10
-        b.column :last, 10
-      end
-      d.footer do |f|
-        f.trap { |line| line[0,4] == 'FOOT' }
-        f.column :type, 4
-        f.column :file_id, 10
-      end
-    end
-    @data = {
-      :header => [ {:type => "HEAD", :file_id => "1" }],
-      :body => [
-        {:first => "Paul", :last => "Hewson" },
-        {:first => "Dave", :last => "Evans" }
-      ],
-      :footer => [ {:type => "FOOT", :file_id => "1" }]
-    }
-    @generator = Slither::Generator.new(@definition)
-  end
-
-  it "should raise an error if there is no data for a required section" do
-    @data.delete :header
-    lambda {  @generator.generate(@data) }.should raise_error(Slither::RequiredSectionEmptyError, "Required section 'header' was empty.")
-  end
-
-  it "should raise an error if there is no data for a required section" do
-    @data[:body] = []
-    lambda {  @generator.generate(@data) }.should raise_error(Slither::RequiredSectionEmptyError, "Required section 'body' was empty.")
-  end
-
-  it "should generate a string" do
-    expected = "HEAD         1\n      Paul    Hewson\n      Dave     Evans\nFOOT         1"
-    @generator.generate(@data).should == expected
-  end
-
-  context "when content is not an array but enumerable" do
-    class CustomEnumerable
-      include Enumerable
-
-      RECORD = {:first => "Paul", :last => "Hewson" }
-
-      def each
-        3.times do
-          yield RECORD
+  context "when trailing newline is not needed based on the definition" do
+    before(:each) do
+      @definition = Slither.define :test do |d|
+        d.header do |h|
+          h.trap { |line| line[0,4] == 'HEAD' }
+          h.column :type, 4
+          h.column :file_id, 10
+        end
+        d.body do |b|
+          b.trap { |line| line[0,4] =~ /[^(HEAD|FOOT)]/ }
+          b.column :first, 10
+          b.column :last, 10
+        end
+        d.footer do |f|
+          f.trap { |line| line[0,4] == 'FOOT' }
+          f.column :type, 4
+          f.column :file_id, 10
         end
       end
+      @data = {
+        :header => [ {:type => "HEAD", :file_id => "1" }],
+        :body => [
+          {:first => "Paul", :last => "Hewson" },
+          {:first => "Dave", :last => "Evans" }
+        ],
+        :footer => [ {:type => "FOOT", :file_id => "1" }]
+      }
+      @generator = Slither::Generator.new(@definition)
     end
 
-    it "should generate expected output" do
-      @data[:body] = CustomEnumerable.new
-      expected = "HEAD         1\n      Paul    Hewson\n      Paul    Hewson\n      Paul    Hewson\nFOOT         1"
+    it "should raise an error if there is no data for a required section" do
+      @data.delete :header
+      lambda {  @generator.generate(@data) }.should raise_error(Slither::RequiredSectionEmptyError, "Required section 'header' was empty.")
+    end
+
+    it "should raise an error if there is no data for a required section" do
+      @data[:body] = []
+      lambda {  @generator.generate(@data) }.should raise_error(Slither::RequiredSectionEmptyError, "Required section 'body' was empty.")
+    end
+
+    it "should generate a string without a trailing newline" do
+      expected = "HEAD         1\n      Paul    Hewson\n      Dave     Evans\nFOOT         1"
       @generator.generate(@data).should == expected
+    end
+
+    context "but needed based on the generator" do
+      before(:each) do
+        @generator = Slither::Generator.new(@definition, true)
+      end
+
+      it "should generate a string with a trailing newline" do
+        expected = "HEAD         1\n      Paul    Hewson\n      Dave     Evans\nFOOT         1\n"
+        @generator.generate(@data).should == expected
+      end
+    end
+
+    context "when content is not an array but enumerable" do
+      class CustomEnumerable
+        include Enumerable
+
+        RECORD = {:first => "Paul", :last => "Hewson" }
+
+        def each
+          3.times do
+            yield RECORD
+          end
+        end
+      end
+
+      it "should generate expected output" do
+        @data[:body] = CustomEnumerable.new
+        expected = "HEAD         1\n      Paul    Hewson\n      Paul    Hewson\n      Paul    Hewson\nFOOT         1"
+        @generator.generate(@data).should == expected
+      end
+    end
+
+    context "when content is hash" do
+      it "should generate expected output" do
+        @data[:body] = {:first => "Paul", :last => "Hewson" }
+        expected = "HEAD         1\n      Paul    Hewson\nFOOT         1"
+        @generator.generate(@data).should == expected
+      end
     end
   end
 
-  context "when content is hash" do
-    it "should generate expected output" do
-      @data[:body] = {:first => "Paul", :last => "Hewson" }
-      expected = "HEAD         1\n      Paul    Hewson\nFOOT         1"
+  context "when trailing newline is needed based on the definition" do
+    before(:each) do
+      @definition = Slither.define :test, trailing_newline: true do |d|
+        d.header do |h|
+          h.trap { |line| line[0,4] == 'HEAD' }
+          h.column :type, 4
+          h.column :file_id, 10
+        end
+        d.body do |b|
+          b.trap { |line| line[0,4] =~ /[^(HEAD|FOOT)]/ }
+          b.column :first, 10
+          b.column :last, 10
+        end
+        d.footer do |f|
+          f.trap { |line| line[0,4] == 'FOOT' }
+          f.column :type, 4
+          f.column :file_id, 10
+        end
+      end
+      @data = {
+        :header => [ {:type => "HEAD", :file_id => "1" }],
+        :body => [
+          {:first => "Paul", :last => "Hewson" },
+          {:first => "Dave", :last => "Evans" }
+        ],
+        :footer => [ {:type => "FOOT", :file_id => "1" }]
+      }
+      @generator = Slither::Generator.new(@definition)
+    end
+
+    it "should generate a string with a trailing newline" do
+      expected = "HEAD         1\n      Paul    Hewson\n      Dave     Evans\nFOOT         1\n"
       @generator.generate(@data).should == expected
+    end
+
+    context "and needed based on the generator" do
+      before(:each) do
+        @generator = Slither::Generator.new(@definition, true)
+      end
+
+      it "should generate a string with a trailing newline" do
+        expected = "HEAD         1\n      Paul    Hewson\n      Dave     Evans\nFOOT         1\n"
+        @generator.generate(@data).should == expected
+      end
     end
   end
 end

--- a/spec/slither_spec.rb
+++ b/spec/slither_spec.rb
@@ -43,7 +43,7 @@ describe Slither do
       generator = mock('generator')
       generator.should_receive(:generate).with({})
       Slither.should_receive(:definition).with(:test).and_return(definition)
-      Slither::Generator.should_receive(:new).with(definition).and_return(generator)
+      Slither::Generator.should_receive(:new).with(definition, false).and_return(generator)
       Slither.generate(:test, {})
     end
 


### PR DESCRIPTION
Background
It is a quick fix to gengerate every file with trailing newlines
https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline

Design: 
#Slither.generate accepts trailing_newline parameter(default false)
Definitions can have an option :trailing_newline

Based on these settings the decision order is the following:
-Definition truthy value(basically an override)
-Slither generate true or false value

With this approach definitions can be turned on 1 by 1, even though slither wanna generates the file without a trailing  newline